### PR TITLE
Adjust regex to accept variables

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -11,7 +11,7 @@ export function UpdateActions(instance: ModuleInstance): void {
 					type: 'textinput',
 					label: 'Location (row/column)',
 					default: '0/0',
-					regex: '/^\\d+\\/\\d+$/',
+					regex: '/^(\\$\\([^:)]+:[^)]+\\)(\\/(\\d+|\\$\\([^:)]+:[^)]+\\)))?|\\d+\\/(\\d+|\\$\\([^:)]+:[^)]+\\)))$/',
 					useVariables: { local: true },
 				},
 				{

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -15,7 +15,7 @@ export function UpdateFeedbacks(instance: ModuleInstance): void {
 					type: 'textinput',
 					label: 'Location (row/column)',
 					default: '0/0',
-					regex: '/^\\d+\\/\\d+$/',
+					regex: '/^(\\$\\([^:)]+:[^)]+\\)(\\/(\\d+|\\$\\([^:)]+:[^)]+\\)))?|\\d+\\/(\\d+|\\$\\([^:)]+:[^)]+\\)))$/',
 					useVariables: { local: true },
 				},
 			],


### PR DESCRIPTION
Allowing combination of companion variables and numbers #3 
| Input | Result |
|---|---|
| `1/2` | ✅ |
| `1/$(a:b)` | ✅ |
| `$(a:b)` | ✅ |
| `$(a:b)/$(c:d)` | ✅ |
| `$(a:b)/1` | ✅ |
| `1` | ❌ |
| `1/2/3` | ❌ |